### PR TITLE
Update inject.ts DOM text reinterpreted as HTML

### DIFF
--- a/codewords_core/src/inject.ts
+++ b/codewords_core/src/inject.ts
@@ -52,7 +52,7 @@ namespace CodeWords {
       document.head.appendChild(style_);
     }
 
-    container.innerHTML = CodeWords.UI.EDITOR_HTML;
+    container.innerText = CodeWords.UI.EDITOR_HTML;
     return new Editor(container.querySelector('.codewords-editor')! as HTMLElement);
   }
 }


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.