### PR TITLE
Update snippet_palette.ts DOM text reinterpreted as HTML

### DIFF
--- a/codewords_core/src/ui/snippet_palette.ts
+++ b/codewords_core/src/ui/snippet_palette.ts
@@ -76,7 +76,7 @@ namespace CodeWords.UI {
 
       // TODO: If the search context search text only changed by a small
       //       amount, save scroll state and animate snippet changes.
-      this.div_.innerHTML = '';
+      this.div_.innerText = '';
       for (const html of snippetHtml) {
         this.div_.appendChild(html);
         this.div_.insertAdjacentText('beforeend', ' ');


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.